### PR TITLE
Update libxml-ruby to ~> 4.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       dry-struct (~> 1.3)
       dry-types (~> 1.4)
       http (~> 4.4)
-      libxml-ruby (~> 3.2)
+      libxml-ruby (~> 4.1)
       oj (~> 3.10)
 
 GEM
@@ -60,7 +60,7 @@ GEM
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
-    libxml-ruby (3.2.4)
+    libxml-ruby (4.1.2)
     method_source (0.9.2)
     minitest (5.19.0)
     oj (3.16.1)
@@ -91,6 +91,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-24
 
 DEPENDENCIES
   bundler (~> 2.3)

--- a/packeta.gemspec
+++ b/packeta.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-struct", "~> 1.3"
   spec.add_dependency "dry-types", "~> 1.4"
   spec.add_dependency "http", "~> 4.4"
-  spec.add_dependency "libxml-ruby", "~> 3.2"
+  spec.add_dependency "libxml-ruby", "~> 4.1"
   spec.add_dependency "oj", "~> 3.10"
   spec.add_development_dependency "bundler", "~> 2.3"
   spec.add_development_dependency "pry", "~> 0.12.2"


### PR DESCRIPTION
Version 4.1.0 fixes a compilation error on newer Macs. See https://github.com/xml4r/libxml-ruby/issues/199 and maybe even https://github.com/xml4r/libxml-ruby/issues/200 and https://github.com/xml4r/libxml-ruby/issues/201.