### PR TITLE
Add courier tracking URLs to packet info result

### DIFF
--- a/lib/packeta/packet_info_result.rb
+++ b/lib/packeta/packet_info_result.rb
@@ -1,4 +1,6 @@
+require 'active_support/core_ext/array/wrap'
 require 'active_support/core_ext/hash/conversions'
+require 'active_support/core_ext/object/blank'
 
 module Packeta
   class PacketInfoResult < Result
@@ -12,6 +14,14 @@ module Packeta
       return unless ok?
 
       Hash.from_xml(response.to_s).dig('response', 'result', 'courierInfo', 'courierInfoItem')
+    end
+
+    def courier_tracking_urls
+      tracking_url_data = to_h&.dig('courierTrackingUrls', 'courierTrackingUrl')
+
+      Array.wrap(tracking_url_data).map do |url_data|
+        url_data&.[]('url').presence
+      end.compact
     end
   end
 end

--- a/lib/packeta/version.rb
+++ b/lib/packeta/version.rb
@@ -1,3 +1,3 @@
 module Packeta
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end

--- a/spec/packeta/requests/packet_info_spec.rb
+++ b/spec/packeta/requests/packet_info_spec.rb
@@ -16,6 +16,15 @@ RSpec.describe Packeta::PacketInfo do
             item << LibXML::XML::Node.new('courierBarcodes').tap do |barcodes|
               barcodes << LibXML::XML::Node.new('courierBarcode').tap { _1.content = barcode }
             end
+            if courier_tracking_url_data.any?
+              item << LibXML::XML::Node.new('courierTrackingUrls').tap do |tracking_urls|
+                courier_tracking_url_data.each do |url_data|
+                  tracking_urls << LibXML::XML::Node.new('courierTrackingUrl').tap do |tracking_url|
+                    tracking_url << LibXML::XML::Node.new('url').tap { _1.content = url_data[:url] } if url_data.key?(:url)
+                  end
+                end
+              end
+            end
           end
         end
       end
@@ -23,6 +32,7 @@ RSpec.describe Packeta::PacketInfo do
 
     let(:barcode) { 'testing_barcode' }
     let(:courier_name) { 'test courier' }
+    let(:courier_tracking_url_data) { [] }
 
     before do
       expect(HTTP)
@@ -47,6 +57,57 @@ RSpec.describe Packeta::PacketInfo do
         }
 
       expect(result.to_h).to eq(expected_info)
+    end
+
+    it 'returns an empty array when courier tracking URLs are missing' do
+      result = request.call
+
+      expect(result.courier_tracking_urls).to eq([])
+    end
+
+    context 'when courierTrackingUrl is returned as an array' do
+      let(:courier_tracking_url_data) do
+        [
+          { url: 'https://tracking.example.test/first' },
+          { url: '' },
+          { url: '   ' },
+          { url: 'https://tracking.example.test/second' }
+        ]
+      end
+
+      it 'returns all non-blank URLs' do
+        result = request.call
+
+        expect(result.courier_tracking_urls).to eq([
+          'https://tracking.example.test/first',
+          'https://tracking.example.test/second'
+        ])
+      end
+    end
+
+    context 'when courierTrackingUrl is returned as a single hash' do
+      let(:courier_tracking_url_data) { [{ url: 'https://tracking.example.test/only' }] }
+
+      it 'returns the URL' do
+        result = request.call
+
+        expect(result.courier_tracking_urls).to eq(['https://tracking.example.test/only'])
+      end
+    end
+
+    context 'when courierTrackingUrl entries have blank or missing URLs' do
+      let(:courier_tracking_url_data) do
+        [
+          { url: '' },
+          {}
+        ]
+      end
+
+      it 'skips blank and missing URLs' do
+        result = request.call
+
+        expect(result.courier_tracking_urls).to eq([])
+      end
     end
   end
 end


### PR DESCRIPTION
Expose `Packeta::PacketInfoResult#courier_tracking_urls`, so the courier tracking links are returned by `packetInfo`.

---

[Asana task](https://app.asana.com/1/1132662667535638/project/1215903872548317/task/1215928650112493?focus=true)
